### PR TITLE
fix: audit Issue #6 - installer & config isolation (tests only)

### DIFF
--- a/__tests__/installer-isolation.test.ts
+++ b/__tests__/installer-isolation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { getMcpServerConfig, getCodeGraphPermissions } from '../src/installer/targets/shared';
+import { getDaemonSocketPath, getDaemonPidPath } from '../src/mcp/daemon-paths';
+import { claudeTarget } from '../src/installer/targets/claude';
+import pkg from '../package.json';
+
+/**
+ * Issue #6: Audit daemon, watcher, index lock, and installer config isolation
+ *
+ * TDD vertical slices — one tracer bullet at a time.
+ *
+ * Slice 1 (tracer): generated installer config uses `zcodegraph` command.
+ *   - Acceptance criterion: "Generated installer configs use `zcodegraph`."
+ */
+describe('Issue #6 — installer config uses zcodegraph', () => {
+  it('getMcpServerConfig() returns command: "zcodegraph" (not "codegraph")', () => {
+    const config = getMcpServerConfig();
+    expect(config.command).toBe('zcodegraph');
+    expect(config.args).toEqual(['serve', '--mcp']);
+    expect(config.type).toBe('stdio');
+  });
+
+  /**
+   * Slice 2 (tracer): permissions use zcodegraph_* tool names.
+   * Acceptance criterion: "Generated installer configs use `zcodegraph`."
+   * The permission strings combine the MCP server KEY (intentionally
+   * kept as "codegraph") with the tool names ("zcodegraph_*").
+   */
+  it('getCodeGraphPermissions() uses mcp__codegraph__zcodegraph_* format', () => {
+    const perms = getCodeGraphPermissions();
+    expect(perms.length).toBeGreaterThan(0);
+    for (const p of perms) {
+      // KEY is "codegraph" (intentional internal identity from Issue #4)
+      // Tool names are "zcodegraph_*" (new identity)
+      expect(p).toMatch(/^mcp__codegraph__zcodegraph_/);
+    }
+  });
+
+  /**
+   * Slice 3 (tracer): daemon socket path is project-scoped.
+   * Acceptance criterion: "Lock paths derive from the target project root"
+   */
+  it('getDaemonSocketPath() returns different paths for different project roots', () => {
+    const pathA = getDaemonSocketPath('/project/A');
+    const pathB = getDaemonSocketPath('/project/B');
+    expect(pathA).not.toBe(pathB);
+  });
+
+  /**
+   * Slice 4: daemon pid path is project-scoped.
+   */
+  it('getDaemonPidPath() returns project-scoped path', () => {
+    const p = getDaemonPidPath('/my/project');
+    expect(p).toContain('.codegraph');
+    expect(p).toContain('daemon.pid');
+  });
+
+  /**
+   * Slice 5 (tracer): generated config does NOT embed a stale
+   * project-absolute path — the command is bare `zcodegraph`,
+   * resolved from PATH at runtime.
+   * Acceptance: "Global install does not embed stale project paths"
+   */
+  it('getMcpServerConfig() command is not an absolute path', () => {
+    const config = getMcpServerConfig();
+    // Should be bare executable name, NOT e.g. /home/user/project/node_modules/.bin/zcodegraph
+    expect(config.command).not.toMatch(/^[a-zA-Z]:[\\\/]|^\//);
+  });
+
+  /**
+   * Slice 6 (tracer): local install writes only to project-local
+   * `.mcp.json`, never to the global `~/.claude.json`.
+   * Acceptance: "Local install writes only to project-local config."
+   */
+  it('local install config path ends with .mcp.json (not .claude.json)', () => {
+    const result = claudeTarget.detect('local');
+    expect(result.configPath).toMatch(/[\\\/]\.mcp\.json$/);
+    expect(result.configPath).not.toMatch(/[\\\/]\.claude\.json$/);
+  });
+});


### PR DESCRIPTION
## Summary

Audit of daemon, watcher, index lock, and installer config isolation (Issue #6).

**Finding**: All acceptance criteria are already satisfied — no repo-controlled bugs found. Added 6 focused tests to document and regress-proof the correct behavior.

## Acceptance Criteria Verification

- [x] **Lock paths derive from target project root** — `src/index.ts` uses `projectRoot` (not `process.cwd()`)
- [x] **Watcher/session state is project-scoped** — `watcher.ts` binds to `projectRoot`; `session.ts` uses `explicitProjectPath` / `roots/list`
- [x] **Local install writes only to project-local config** — `mcpJsonPath('local')` → `<cwd>/.mcp.json`
- [x] **Global install does not embed stale project paths** — `getMcpServerConfig()` returns `{ command: 'zcodegraph', args: ['serve', '--mcp'] }` (no path)
- [x] **Generated installer configs use `zcodegraph`** — `getMcpServerConfig()` returns `command: 'zcodegraph'`
- [x] **Focused tests pass** — 6/6 ✅

## Changes

| File | Change |
|------|--------|
| `__tests__/installer-isolation.test.ts` | New: 6 tests documenting audit findings |

## Tests Added

1. `getMcpServerConfig() returns command: "zcodegraph"` ✅
2. `getCodeGraphPermissions() uses mcp__codegraph__zcodegraph_*` ✅
3. `getDaemonSocketPath() returns different paths for different project roots` ✅
4. `getDaemonPidPath() returns project-scoped path` ✅
5. `getMcpServerConfig() command is not an absolute path` ✅
6. `local install config path ends with .mcp.json` ✅

Closes #6
